### PR TITLE
Add Accounts shortcut to sidebar navigation

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,6 @@
 <% mobile_nav_items = [
   { name: "Home", path: root_path, icon: "pie-chart", icon_custom: false, active: page_active?(root_path) },
+  { name: "Accounts", path: accounts_path, icon: "wallet", icon_custom: false, active: page_active?(accounts_path) },
   { name: "Transactions", path: transactions_path, icon: "credit-card", icon_custom: false, active: page_active?(transactions_path) },
   { name: "Budgets", path: budgets_path, icon: "map", icon_custom: false, active: page_active?(budgets_path) },
   { name: "Assistant", path: chats_path, icon: "icon-assistant", icon_custom: true, active: page_active?(chats_path), mobile_only: true }


### PR DESCRIPTION
Add wallet icon link to /accounts in both desktop and mobile nav bars, positioned between Home and Transactions for easy access.