### PR TITLE
Add API endpoint to sync all accounts

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -4,7 +4,8 @@ class Api::V1::AccountsController < Api::V1::BaseController
   include Pagy::Backend
 
   # Ensure proper scope authorization for read access
-  before_action :ensure_read_scope
+  before_action :ensure_read_scope, only: :index
+  before_action :ensure_write_scope, only: :sync_all
 
   def index
     # Test with Pagy pagination
@@ -30,12 +31,44 @@ class Api::V1::AccountsController < Api::V1::BaseController
       error: "internal_server_error",
       message: "Error: #{e.message}"
     }, status: :internal_server_error
+  end
+
+  def sync_all
+    family = current_resource_owner.family
+
+    if family.syncing?
+      render_json({ message: "Sync already in progress" }, status: :ok)
+    else
+      family.sync_later
+      sync = family.syncs.order(created_at: :desc).first
+
+      render_json({
+        message: "Sync initiated for all accounts",
+        sync: {
+          id: sync&.id,
+          status: sync&.status,
+          created_at: sync&.created_at
+        }
+      }, status: :accepted)
+    end
+  rescue => e
+    Rails.logger.error "AccountsController#sync_all error: #{e.message}"
+    Rails.logger.error e.backtrace.join("\n")
+
+    render json: {
+      error: "internal_server_error",
+      message: "Error: #{e.message}"
+    }, status: :internal_server_error
 end
 
     private
 
       def ensure_read_scope
         authorize_scope!(:read)
+      end
+
+      def ensure_write_scope
+        authorize_scope!(:write)
       end
 
 

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -3,16 +3,13 @@
 class Api::V1::AccountsController < Api::V1::BaseController
   include Pagy::Backend
 
-  # Ensure proper scope authorization for read access
   before_action :ensure_read_scope, only: :index
   before_action :ensure_write_scope, only: :sync_all
 
   def index
-    # Test with Pagy pagination
     family = current_resource_owner.family
     accounts_query = family.accounts.visible.alphabetically
 
-    # Handle pagination with Pagy
     @pagy, @accounts = pagy(
       accounts_query,
       page: safe_page_param,
@@ -21,72 +18,67 @@ class Api::V1::AccountsController < Api::V1::BaseController
 
     @per_page = safe_per_page_param
 
-    # Rails will automatically use app/views/api/v1/accounts/index.json.jbuilder
     render :index
   rescue => e
-    Rails.logger.error "AccountsController error: #{e.message}"
+    Rails.logger.error "AccountsController#index error: #{e.message}"
     Rails.logger.error e.backtrace.join("\n")
-
-    render json: {
-      error: "internal_server_error",
-      message: "Error: #{e.message}"
-    }, status: :internal_server_error
+    render_json({ error: "internal_server_error", message: "An unexpected error occurred" }, status: :internal_server_error)
   end
 
   def sync_all
     family = current_resource_owner.family
+    existing_sync = family.syncs.incomplete.first
 
-    if family.syncing?
-      render_json({ message: "Sync already in progress" }, status: :ok)
+    if existing_sync
+      render_json({
+        message: "Sync already in progress",
+        sync: sync_payload(existing_sync)
+      }, status: :ok)
     else
-      family.sync_later
-      sync = family.syncs.order(created_at: :desc).first
+      sync = family.sync_later
 
       render_json({
         message: "Sync initiated for all accounts",
-        sync: {
-          id: sync&.id,
-          status: sync&.status,
-          created_at: sync&.created_at
-        }
+        sync: sync_payload(sync)
       }, status: :accepted)
     end
   rescue => e
     Rails.logger.error "AccountsController#sync_all error: #{e.message}"
     Rails.logger.error e.backtrace.join("\n")
+    render_json({ error: "internal_server_error", message: "An unexpected error occurred" }, status: :internal_server_error)
+  end
 
-    render json: {
-      error: "internal_server_error",
-      message: "Error: #{e.message}"
-    }, status: :internal_server_error
-end
+  private
 
-    private
+    def ensure_read_scope
+      authorize_scope!(:read)
+    end
 
-      def ensure_read_scope
-        authorize_scope!(:read)
+    def ensure_write_scope
+      authorize_scope!(:write)
+    end
+
+    def sync_payload(sync)
+      {
+        id: sync.id,
+        status: sync.status,
+        created_at: sync.created_at
+      }
+    end
+
+    def safe_page_param
+      page = params[:page].to_i
+      page > 0 ? page : 1
+    end
+
+    def safe_per_page_param
+      per_page = params[:per_page].to_i
+
+      case per_page
+      when 1..100
+        per_page
+      else
+        25
       end
-
-      def ensure_write_scope
-        authorize_scope!(:write)
-      end
-
-
-
-      def safe_page_param
-        page = params[:page].to_i
-        page > 0 ? page : 1
-      end
-
-      def safe_per_page_param
-        per_page = params[:per_page].to_i
-
-        # Default to 25, max 100
-        case per_page
-        when 1..100
-          per_page
-        else
-          25
-        end
-      end
+    end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -209,7 +209,11 @@ Rails.application.routes.draw do
       post "auth/refresh", to: "auth#refresh"
 
       # Production API endpoints
-      resources :accounts, only: [ :index ]
+      resources :accounts, only: [ :index ] do
+        collection do
+          post :sync, action: :sync_all
+        end
+      end
       resources :transactions, only: [ :index, :show, :create, :update, :destroy ]
       resource :usage, only: [ :show ], controller: "usage"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -211,7 +211,7 @@ Rails.application.routes.draw do
       # Production API endpoints
       resources :accounts, only: [ :index ] do
         collection do
-          post :sync, action: :sync_all
+          post :sync_all
         end
       end
       resources :transactions, only: [ :index, :show, :create, :update, :destroy ]

--- a/test/controllers/api/v1/accounts_controller_test.rb
+++ b/test/controllers/api/v1/accounts_controller_test.rb
@@ -214,4 +214,89 @@ end
     account_names = response_body["accounts"].map { |a| a["name"] }
     assert_equal account_names.sort, account_names
   end
+
+  # === sync_all tests ===
+
+  test "sync_all should require authentication" do
+    post "/api/v1/accounts/sync_all"
+    assert_response :unauthorized
+  end
+
+  test "sync_all should require write scope" do
+    access_token = Doorkeeper::AccessToken.create!(
+      application: @oauth_app,
+      resource_owner_id: @user.id,
+      scopes: "read"
+    )
+
+    post "/api/v1/accounts/sync_all", headers: {
+      "Authorization" => "Bearer #{access_token.token}"
+    }
+
+    assert_response :forbidden
+    response_body = JSON.parse(response.body)
+    assert_equal "insufficient_scope", response_body["error"]
+  end
+
+  test "sync_all should initiate sync and return 202" do
+    access_token = Doorkeeper::AccessToken.create!(
+      application: @oauth_app,
+      resource_owner_id: @user.id,
+      scopes: "read_write"
+    )
+
+    post "/api/v1/accounts/sync_all", headers: {
+      "Authorization" => "Bearer #{access_token.token}"
+    }
+
+    assert_response :accepted
+    response_body = JSON.parse(response.body)
+
+    assert_equal "Sync initiated for all accounts", response_body["message"]
+    assert response_body.key?("sync")
+    assert response_body["sync"].key?("id")
+    assert_equal "pending", response_body["sync"]["status"]
+    assert response_body["sync"].key?("created_at")
+  end
+
+  test "sync_all should return 200 with sync info when sync already in progress" do
+    access_token = Doorkeeper::AccessToken.create!(
+      application: @oauth_app,
+      resource_owner_id: @user.id,
+      scopes: "read_write"
+    )
+
+    # Create an incomplete sync
+    existing_sync = @user.family.syncs.create!(status: :pending)
+
+    post "/api/v1/accounts/sync_all", headers: {
+      "Authorization" => "Bearer #{access_token.token}"
+    }
+
+    assert_response :ok
+    response_body = JSON.parse(response.body)
+
+    assert_equal "Sync already in progress", response_body["message"]
+    assert response_body.key?("sync")
+    assert_equal existing_sync.id, response_body["sync"]["id"]
+    assert_equal "pending", response_body["sync"]["status"]
+  end
+
+  test "sync_all should work with API key authentication" do
+    plain_key = ApiKey.generate_secure_key
+    @user.api_keys.create!(
+      name: "test-key",
+      display_key: plain_key,
+      scopes: [ "read_write" ],
+      source: "web"
+    )
+
+    post "/api/v1/accounts/sync_all", headers: {
+      "X-Api-Key" => plain_key
+    }
+
+    assert_response :accepted
+    response_body = JSON.parse(response.body)
+    assert_equal "Sync initiated for all accounts", response_body["message"]
+  end
 end


### PR DESCRIPTION
POST /api/v1/accounts/sync triggers a family-level sync which cascades to all connected accounts (Plaid, SimpleFin, Klutch, manual). Requires read_write scope. Returns 202 with sync ID and status, or 200 if a sync is already in progress.